### PR TITLE
Fix Gradle version catalog syntax in get_started.topic

### DIFF
--- a/docs/Writerside/topics/get_started.topic
+++ b/docs/Writerside/topics/get_started.topic
@@ -138,7 +138,7 @@
 
                     [libraries]
                     //...
-                    kotlinmailer-core = { module = "at.quickme.kotlinmailer", name = "core", version.ref = "kotlinmailer" }
+                    kotlinmailer-core = { module = "at.quickme.kotlinmailer:core", version.ref = "kotlinmailer" }
                 </code-block>
                 <list>
                     <li>


### PR DESCRIPTION
Hi!

This PR just fixes a small syntax issue in the Gradle version catalog syntax for the core Kotlinmailer artifact.

As per [Gradle version catalog docs](https://docs.gradle.org/current/userguide/version_catalogs.html#libraries), artifacts can either be referenced as `group` and `name`, or a combined `module` string.